### PR TITLE
PATCH: Add option to fetch the height from poktscan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "axios": "^0.27.2",
                 "express": "^4.18.1",
+                "graphql-request": "^6.1.0",
                 "pino": "^7.11.0",
                 "prom-client": "^14.0.1"
             },
@@ -39,6 +40,14 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@graphql-typed-document-node/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
             }
         },
         "node_modules/@tsconfig/node10": {
@@ -304,6 +313,14 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
+        "node_modules/cross-fetch": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+            "dependencies": {
+                "node-fetch": "^2.6.12"
+            }
+        },
         "node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -523,6 +540,27 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/graphql": {
+            "version": "16.8.1",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+            "peer": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
+        },
+        "node_modules/graphql-request": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+            "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.2.0",
+                "cross-fetch": "^3.1.5"
+            },
+            "peerDependencies": {
+                "graphql": "14 - 16"
+            }
+        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -652,6 +690,25 @@
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/object-inspect": {
@@ -977,6 +1034,11 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "node_modules/ts-node": {
             "version": "10.7.0",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
@@ -1080,6 +1142,20 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1110,6 +1186,12 @@
             "requires": {
                 "@cspotcode/source-map-consumer": "0.8.0"
             }
+        },
+        "@graphql-typed-document-node/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+            "requires": {}
         },
         "@tsconfig/node10": {
             "version": "1.0.8",
@@ -1337,6 +1419,14 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
+        "cross-fetch": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+            "requires": {
+                "node-fetch": "^2.6.12"
+            }
+        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1502,6 +1592,21 @@
                 "has-symbols": "^1.0.1"
             }
         },
+        "graphql": {
+            "version": "16.8.1",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+            "peer": true
+        },
+        "graphql-request": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+            "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+            "requires": {
+                "@graphql-typed-document-node/core": "^3.2.0",
+                "cross-fetch": "^3.1.5"
+            }
+        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1593,6 +1698,14 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+        },
+        "node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
         },
         "object-inspect": {
             "version": "1.12.0",
@@ -1848,6 +1961,11 @@
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "ts-node": {
             "version": "10.7.0",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
@@ -1909,6 +2027,20 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dependencies": {
         "axios": "^0.27.2",
         "express": "^4.18.1",
+        "graphql-request": "^6.1.0",
         "pino": "^7.11.0",
         "prom-client": "^14.0.1"
     }

--- a/src/height-strategies/pocket.ts
+++ b/src/height-strategies/pocket.ts
@@ -1,7 +1,8 @@
-import axios from "axios"
-import { HeightStrategy } from "."
-import { logger } from ".."
-import { localRPCWrapper, remoteRPCIterator } from "../common"
+import axios from "axios"; // Optional if you need it for other REST calls
+import { HeightStrategy } from ".";
+import { logger } from "..";
+import { localRPCWrapper, remoteRPCIterator } from "../common";
+import { GraphQLClient, request } from 'graphql-request';
 
 const getHeight = async (url: string) => {
     const result = await axios({
@@ -28,12 +29,57 @@ const getHeight = async (url: string) => {
     }
 }
 
+// PoktScan GraphQL-based height fetching logic
+
+interface GetLatestBlockResponse {
+    GetLatestBlock: {
+        block: {
+            height: number;
+            time: string; // Or whatever the actual type of 'time' is
+        }
+    }
+}
+
+const getPoktscanHeight = async () => {
+    const query = `
+    {
+        GetLatestBlock {
+            block {
+                height
+                time
+            }
+        }
+    }
+    `;
+
+    const headers = {
+        'authorization': process.env.POKTSCAN_API_KEY
+    }
+
+    try {
+        const client = new GraphQLClient(process.env.POKTSCAN_ENDPOINT, { headers });
+        const data: GetLatestBlockResponse = await client.request(query);
+        return data.GetLatestBlock.block.height;
+
+    } catch (error) {
+        logger.error('Error fetching height from Poktscan:', error);
+        throw error;
+    }
+}
+
 const pocket: HeightStrategy = {
     name: 'pocket',
     getLocalHeight: () => localRPCWrapper(getHeight),
-    getRemoteHeight: () => remoteRPCIterator(getHeight),
+    getRemoteHeight: () => {
+        if (process.env.USE_POKTSCAN === 'true') {
+            return getPoktscanHeight();
+        } else {
+            return remoteRPCIterator(getHeight);
+        }
+    },
     init: async () => {
-        logger.info(`Pocket height check strategy initiated`)
+        const strategy = process.env.USE_POKTSCAN === 'true' ? 'Poktscan' : 'REST';
+        logger.info(`Pocket height check strategy initiated (using ${strategy})`);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,86 +6,92 @@ import { requireEnvar } from "./common";
 import { currentHeightRequestStrategy } from "./height-strategies";
 import { currentProbeStrategies } from "./probe-strategies";
 import { sidecarState } from "./state";
-import os from 'os';
 
-const {
-    INCLUDE_NODEJS_METRICS,
-    LOG_LEVEL,
-    LISTEN_PORT,
-} = process.env;
+const { INCLUDE_NODEJS_METRICS, LOG_LEVEL, LISTEN_PORT } = process.env;
 
-export const logger = pino({ level: LOG_LEVEL || 'info' })
+export const logger = pino({ level: LOG_LEVEL || "info" });
 const listenPort = Number(LISTEN_PORT || 9090);
 const app = express();
 
 // In case we want to troubleshoot the healthcheck sidecar itself.
 if (INCLUDE_NODEJS_METRICS === "true") {
-    collectDefaultMetrics({ register });
+  collectDefaultMetrics({ register });
 }
 
 // Exposes metrics as Prometheus exporter
 app.get("/metrics", async (_req, res) => {
-    try {
-        res.set("Content-Type", register.contentType);
-        res.end(await register.metrics());
-    } catch (ex) {
-        res.status(500).end(ex);
-    }
+  try {
+    res.set("Content-Type", register.contentType);
+    res.end(await register.metrics());
+  } catch (ex) {
+    res.status(500).end(ex);
+  }
 });
 
 // Set global sidecar settings
-const chainID = requireEnvar('SIDECAR_CHAIN_ID')
-const localRPCEndpoint = requireEnvar('LOCAL_RPC_ENDPOINT')
-const remoteRPCEndpoints = process.env.USE_POKTSCAN !== 'true'
+const chainID = requireEnvar("SIDECAR_CHAIN_ID");
+const localRPCEndpoint = requireEnvar("LOCAL_RPC_ENDPOINT");
+const remoteRPCEndpoints =
+  process.env.USE_POKTSCAN !== "true"
     ? [] // Provide an empty array if USE_POKTSCAN is true
-    : (requireEnvar('REMOTE_RPC_ENDPOINTS') || '').split(',');
-const performRemoteChecks = remoteRPCEndpoints.length != 0
-Object.assign(sidecarState, { chainID, localRPCEndpoint, remoteRPCEndpoints, performRemoteChecks });
+    : (requireEnvar("REMOTE_RPC_ENDPOINTS") || "").split(",");
+const performRemoteChecks = remoteRPCEndpoints.length != 0;
+Object.assign(sidecarState, {
+  chainID,
+  localRPCEndpoint,
+  remoteRPCEndpoints,
+  performRemoteChecks,
+});
 
 (async () => {
-    // Configure probes
-    const { readiness, liveness, startup } = currentProbeStrategies
+  // Configure probes
+  const { readiness, liveness, startup } = currentProbeStrategies;
 
-    // Init probe strategies if they have any init code
-    readiness.init ? await readiness.init() : null
-    liveness.init ? await liveness.init() : null
-    startup.init ? await startup.init() : null
+  // Init probe strategies if they have any init code
+  readiness.init ? await readiness.init() : null;
+  liveness.init ? await liveness.init() : null;
+  startup.init ? await startup.init() : null;
 
-    // Readiness probes determine whether or not a container is ready to serve requests.
-    // If the readiness probe returns a non-200 response, Kubernetes removes the IP address of the container from the endpoints of all Services.
-    app.get("/health/readiness", readiness.httpHandler);
-    app.get("/health/liveness", liveness.httpHandler);
-    app.get("/health/startup", startup.httpHandler);
-    logger.info({
-        readiness: readiness.name,
-        liveness: liveness.name,
-        startup: startup.name,
-    }, 'checks/probes selected');
+  // Readiness probes determine whether or not a container is ready to serve requests.
+  // If the readiness probe returns a non-200 response, Kubernetes removes the IP address of the container from the endpoints of all Services.
+  app.get("/health/readiness", readiness.httpHandler);
+  app.get("/health/liveness", liveness.httpHandler);
+  app.get("/health/startup", startup.httpHandler);
+  logger.info(
+    {
+      readiness: readiness.name,
+      liveness: liveness.name,
+      startup: startup.name,
+    },
+    "checks/probes selected",
+  );
 
-    // Configure height checks
-    const { init } = currentHeightRequestStrategy
-    init ? await init() : null
+  // Configure height checks
+  const { init } = currentHeightRequestStrategy;
+  init ? await init() : null;
 
-    // Do very first run
-    await performChecks();
+  // Do very first run
+  await performChecks();
 
-    // Set up checks to run periodically
-    const timer = setInterval(() => performChecks(), sidecarState.checkIntervalMs);
-    logger.info(`Running checks every ${sidecarState.checkIntervalMs}ms`);
+  // Set up checks to run periodically
+  const timer = setInterval(
+    () => performChecks(),
+    sidecarState.checkIntervalMs,
+  );
+  logger.info(`Running checks every ${sidecarState.checkIntervalMs}ms`);
 
-    // Start web server
-    const server = app.listen(listenPort);
-    logger.info(`Listening on :${listenPort}`);
+  // Start web server
+  const server = app.listen(listenPort);
+  logger.info(`Listening on :${listenPort}`);
 
-    // Handle termination
-    process.on("SIGTERM", () => {
-        logger.info("SIGTERM signal received: stopping periodic checks");
-        clearInterval(timer)
+  // Handle termination
+  process.on("SIGTERM", () => {
+    logger.info("SIGTERM signal received: stopping periodic checks");
+    clearInterval(timer);
 
-        logger.info("SIGTERM signal received: closing HTTP server");
-        server.close(() => {
-            logger.info("HTTP server closed");
-        });
+    logger.info("SIGTERM signal received: closing HTTP server");
+    server.close(() => {
+      logger.info("HTTP server closed");
     });
-})()
-
+  });
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { requireEnvar } from "./common";
 import { currentHeightRequestStrategy } from "./height-strategies";
 import { currentProbeStrategies } from "./probe-strategies";
 import { sidecarState } from "./state";
+import os from 'os';
 
 const {
     INCLUDE_NODEJS_METRICS,
@@ -35,7 +36,9 @@ app.get("/metrics", async (_req, res) => {
 // Set global sidecar settings
 const chainID = requireEnvar('SIDECAR_CHAIN_ID')
 const localRPCEndpoint = requireEnvar('LOCAL_RPC_ENDPOINT')
-const remoteRPCEndpoints = (requireEnvar('REMOTE_RPC_ENDPOINTS') || '').split(',')
+const remoteRPCEndpoints = process.env.USE_POKTSCAN !== 'true'
+    ? [] // Provide an empty array if USE_POKTSCAN is true
+    : (requireEnvar('REMOTE_RPC_ENDPOINTS') || '').split(',');
 const performRemoteChecks = remoteRPCEndpoints.length != 0
 Object.assign(sidecarState, { chainID, localRPCEndpoint, remoteRPCEndpoints, performRemoteChecks });
 


### PR DESCRIPTION
This:
- adds the option to fetch the pokt chain height from the poktscan api.
  - Makes the `REMOTE_RPC_ENDPOINTS` env var only required if the `USE_POKTSCAN` env var is not set
  - If `USE_POKTSCAN` is set, the it uses both `POKTSCAN_API_KEY` and `POKTSCAN_ENDPOINT` to make the GraphQL api call to fetch chain height